### PR TITLE
[latest] publish built-ins to Open VSX registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,17 +97,22 @@ Publish packages with lerna to update versions properly across local packages, [
 
 ## Package built-ins as individual `.vsix`
 
-If required, step the version to be used for the extensions in `src/package-vsix.js`
+The version of the packaged built-ins is automatically taken from the VS Code's `package.json` and will also include the SHA of the HEAD VS Code commit if packaging a "next" version.
 
-    // bump to publish
-    let version = '0.2.1';
+To package, use one of the following:
 
-Generate .vsix extensions
+Latest / solid revision:
 
     yarn package-vsix:latest
 
-or
+Next / interim revision:
 
     yarn package-vsix:next
 
-The `.vsix` extensions will be under folder `./dist`
+The generated `.vsix` will be under folder `./dist`
+
+## Publishing VS Code "Builtins" to open-vsx
+
+After generating the `.vsix` (see above), you may examine/test the extensions under folder `dist`. Remove any that you do not wish to be published (e.g. those not working well). When ready proceed with publishing:
+
+    yarn publish:latest

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
         "build:extensions": "yarn --cwd vscode && yarn compile:extensions",
         "compile:extensions": "NODE_OPTIONS=--max-old-space-size=8192 node ./src/compile.js",
         "bundle:extensions": "NODE_OPTIONS=--max-old-space-size=8192 node ./src/bundle.js",
-        "publish:latest": "node ./src/publish.js --tag=latest",
+        "publish": "yarn && yarn publish:latest",
+        "publish:latest": "node ./src/publish-vsix.js --tag=latest",
         "publish:next": "node ./src/publish.js --tag=next",
         "rebuild:browser": "theia rebuild:browser",
         "rebuild:electron": "theia rebuild:electron",
@@ -22,7 +23,8 @@
         "lerna": "2.4.0",
         "vsce": "1.70.0",
         "fs-extra": "8.1.0",
-        "capitalize": "^2.0.2"
+        "capitalize": "^2.0.2",
+        "ovsx": "latest"
     },
     "workspaces": [
         "vscode-builtin-extensions",

--- a/src/package-vsix.js
+++ b/src/package-vsix.js
@@ -17,26 +17,26 @@ const repository = {
     "url": "https://github.com/theia-ide/vscode-builtin-extensions"
 };
 
-// bump to publish
-let version = '1.39.1-prel';
+const vscodePck = JSON.parse(fs.readFileSync(vscode('package.json'), 'utf-8'));
+let version = vscodePck.version || '0.0.1';
 
 (async () => {
-
     const bin = await run('yarn', ['bin'], root());
     const vsce = bin.trim() + '/vsce';
 
+    // use VS Code version and SHA when publishing next
     if (tag === 'next') {
         const shortRevision = (await run('git', ['rev-parse', '--short', 'HEAD'], vscode())).trim();
-        const [, minor] = version.split('.');
-        version = `0.${Number(minor) + 1}.0-next.${shortRevision}`;
+        version += `-${shortRevision}`;
     }
+    console.log(`Packaging builtins from VS Code version: ${version}\n`);
 
     const result = [];
 
     // typescript-language-features ext needs "extensions/node_modules" content
     // and a bit of massaging to work as standalone .vsix, so that the TS LS will 
-    // be packaged and found at runtime. 
-    // Basically replace this:
+    // be packaged-along and available to the extension at runtime. 
+    // Basically we replace this:
     //      "vscode.typescript-language-features",["..","node_modules"]
     // with this:
     //      "vscode.typescript-language-features",[".","deps"]
@@ -56,7 +56,7 @@ let version = '1.39.1-prel';
         }
         else {
             console.log('TS language extension is already patched')
-        }        
+        }
     }
 
     if (!fs.existsSync(dist())) {
@@ -78,24 +78,25 @@ let version = '1.39.1-prel';
         const pck = JSON.parse(originalContent);
         const nlsContent = fs.readFileSync(nlsPath, 'utf-8');
         const nls = JSON.parse(nlsContent);
-        
+
         // note: do change pck.publisher - it's part of the key used to
         // lookup extensions, and so changing it may prevent dependent extensions
-        // to not find it
-        // pck.displayName = nls.displayName || extDisplayName + " (built-in)";
-        pck.displayName = nls.displayName? nls.displayName + " (built-in)" : extDisplayName ;
+        // from finding it
+        pck.displayName = nls.displayName ? nls.displayName + " (built-in)" : extDisplayName;
         pck.description = nls.description || "Built-in extension that adds (potentially basic) support for " + capitalize(pck.name);
         pck.keywords = ["Built-in"];
         pck.repository = repository;
         pck.version = version;
-        
+
         // avoid having vsce run scripts during packaging, such as "vscode-prepublish"
         pck.scripts = {};
 
+        const extLicense = extensions(extension, 'LICENSE-vscode.txt');
         console.log('packaging vsix: ', pck.name, ' ...');
         try {
             fs.writeFileSync(pckPath, JSON.stringify(pck, undefined, 2), 'utf-8');
             fs.writeFileSync(readmePath, readmeContent, 'utf-8');
+            fs.copyFileSync(vscode('LICENSE.txt'), extLicense);
             await run(vsce, ['package', '--yarn', '-o', dist()], extensions(extension));
             result.push('sucessfully packaged: ' + pck.name);
         } catch (e) {
@@ -106,19 +107,32 @@ let version = '1.39.1-prel';
         } finally {
             fs.writeFileSync(pckPath, originalContent, 'utf-8');
             fs.removeSync(readmePath);
+            fs.removeSync(extLicense);
         }
-
     }
-    
+
     console.log(result.join(os.EOL));
 })();
 
 // a very basic README to add to the extension to explain what it is
 function genReadme(ext) {
     return `# Built-in extension: ${ext}
-        
-Built-in are extensions that are included in \`VS Code\` and \`Code OSS\` They are part of the [vscode GitHub repository](https://github.com/microsoft/vscode/tree/master/extensions) and built along with it. 
 
-So if you are running \`VS Code\` or \`Code OSS\` you probably do not need to add them, but other editors might`;
+## Disclaimer
     
+Microsoft does not endorse, build, test or publish this extension, nor are they involved with it in any other way. The only association is that they own the copyright of these extensions and the rest of vscode's [source code](https://github.com/microsoft/vscode/tree/master/extensions), which they released under the [MIT License](https://github.com/microsoft/vscode/blob/master/LICENSE.txt). A copy of the license is included in this extension. See LICENSE-vscode.txt
+
+    "Original VS Code sources are Copyright (c) 2015 - present Microsoft Corporation."
+
+
+## What is this extension? Do I need it?
+
+TL;DR: If you are running \`VS Code\`, \`Code OSS\` or derived product built from the VS Code repository, such as [VSCodium](https://github.com/VSCodium/vscodium), you do not need to install this extension since it's already present - "builtin".
+
+Built-in extensions are built-along and included in \`VS Code\` and \`Code OSS\`. In consequence they may be expected to be present and used by other extensions. They are part of the [vscode GitHub repository](https://github.com/microsoft/vscode/tree/master/) and generally contribute basic functionality such as textmate grammars, used for syntax-highlighting, for some of the most popular programming languages. In some cases, more substantial features are contributed through built-in extensions (e.g. Typescript, Markdown, git, ...). Please see the description above to learn what this specific extension does.
+
+To learn more about builtin extensions, including how they are built and packaged, please see [vscode-builtin-extensions](https://github.com/theia-ide/vscode-builtin-extensions)
+
+`;
+
 }

--- a/src/publish-vsix.js
+++ b/src/publish-vsix.js
@@ -1,0 +1,42 @@
+/**
+ * Publish individual built-in VS Code extensions to an
+ * Open VSX registry (default: open-vsx.org) . It is 
+ * assumed that the extensions to be published are present
+ * in directory "dist" at the root of this repo.
+ * 
+ * The publishing of the extensions is delegated to `ovsx`,
+ * which uses the following environment variables to know
+ * to which registry to publish-to and what personal 
+ * authentication token to use to authenticate:
+ *  OVSX_REGISTRY_URL, OVSX_PAT
+ */
+// @ts-check
+const fs = require('fs')
+const os = require('os');
+const yargs = require('yargs');
+const { root, dist, run } = require('./paths.js');
+
+const { tag } = yargs.option('tag', {
+    choices: ['latest', 'next']
+}).demandOption('tag').argv;
+
+(async () => {
+    if (tag === 'next') {
+        console.error("Open VSX does not support publishing 'next' versions at this time");
+        return;
+    }
+
+    const bin = await run('yarn', ['bin'], root());
+    const ovsx = bin.trim() + '/ovsx';
+    const result = [];
+
+    for (const vsix of fs.readdirSync(dist())) {
+        try {
+            console.log('publishing: ', dist(vsix), ' ...');
+            await run(ovsx, ['publish', dist(vsix)]);
+        } catch (e) {
+            result.push(`failed to publish ${vsix}`);
+        }
+    }
+    console.log(result.join(os.EOL));
+})();

--- a/yarn.lock
+++ b/yarn.lock
@@ -7150,7 +7150,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
+lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -8206,6 +8206,13 @@ osenv@0, osenv@^0.1.3, osenv@^0.1.4:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+ovsx@latest:
+  version "0.1.0-next.9321255"
+  resolved "https://registry.yarnpkg.com/ovsx/-/ovsx-0.1.0-next.9321255.tgz#dbb679e2eacf28017cfd474487a94008426d024d"
+  integrity sha512-gGQRzQWHBT6VdjZZgGxQUN1oaRxBuKcTkhtkL9AMstLqIu+tVmbTjJIE/j/RQeSumsn+HPoXysjnR0fzKsHkdQ==
+  dependencies:
+    vsce "^1.73.0"
 
 p-cancelable@^0.3.0:
   version "0.3.0"
@@ -11146,6 +11153,32 @@ vsce@1.70.0:
     didyoumean "^1.2.1"
     glob "^7.0.6"
     lodash "^4.17.10"
+    markdown-it "^8.3.1"
+    mime "^1.3.4"
+    minimatch "^3.0.3"
+    osenv "^0.1.3"
+    parse-semver "^1.1.1"
+    read "^1.0.7"
+    semver "^5.1.0"
+    tmp "0.0.29"
+    typed-rest-client "1.2.0"
+    url-join "^1.1.0"
+    yauzl "^2.3.1"
+    yazl "^2.2.2"
+
+vsce@^1.73.0:
+  version "1.74.0"
+  resolved "https://registry.yarnpkg.com/vsce/-/vsce-1.74.0.tgz#ed70a20d08c70e63d21b99fc35428c4c8efc0a82"
+  integrity sha512-8zWM9bZBNn9my40kkxAxdY4nhb9ADfazXsyDgx1thbRaLPbmPTlmqQ55vCAyWYFEi6XbJv8w599vzVUqsU1gHg==
+  dependencies:
+    azure-devops-node-api "^7.2.0"
+    chalk "^2.4.2"
+    cheerio "^1.0.0-rc.1"
+    commander "^2.8.1"
+    denodeify "^1.2.1"
+    didyoumean "^1.2.1"
+    glob "^7.0.6"
+    lodash "^4.17.15"
     markdown-it "^8.3.1"
     mime "^1.3.4"
     minimatch "^3.0.3"


### PR DESCRIPTION
Added /src/publish-vsix.js to permit publishing to an Open VSX registry.
To publish to a specific registry, use environment variable
OVSX_REGISTRY_URL to point to it.

Use environment variable OVSX_PAT to store your access token for the
registry.

Also now package "next" version of builtins with version number that reflect
the VS Code source version and commit that they were built from.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>